### PR TITLE
Unused parameter name in startScope function

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -180,7 +180,7 @@ class TreeEmitter implements Emitter {
     }
     closeAllNodes() {}
 
-    startScope(name: string): void {}
+    startScope(_name: string): void {}
     endScope(): void {}
 
     finalize() {}


### PR DESCRIPTION
changed startScope function parameter "name" to "_name" to ensure successful compilation with "noUnusedParameters" flag enabled