### PR TITLE
Fixed broken highlighting

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -141,12 +141,6 @@ class TreeEmitter implements Emitter {
         }
     }
 
-    addKeyword(value: string, name: string) {
-        this.openNode(name);
-        this.addText(value);
-        this.closeNode();
-    }
-
     __addSublanguage(other: Emitter, name: string) {
         var current = this.stack[this.stack.length - 1];
         var results = (other as unknown as TreeEmitter).root.children;
@@ -180,8 +174,13 @@ class TreeEmitter implements Emitter {
     }
     closeAllNodes() {}
 
-    startScope(_name: string): void {}
-    endScope(): void {}
+    startScope(name: string): void {
+        this.openNode(name);
+    }
+    
+    endScope(): void {
+        this.closeNode();
+    }
 
     finalize() {}
     toHTML() {


### PR DESCRIPTION
Apparently highlight.js Emitter api has changed - the addKeyword function has been removed and the startScope function and the endScope function have been added. Oddly enough, they removed the openNode and closeNode functions from .d.ts, but they are still called. More info: https://github.com/highlightjs/highlight.js/issues/3621